### PR TITLE
Only bail on undefined element if it is the only child

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function find(selector, el) {
       isString(el.children) ||
       !el.children ||
       // sometimes mithril spits out an array with only one undefined.
-      (isArray(el.children) && !el.children[0])
+      (isArray(el.children) && el.children.length === 1 && !el.children[0])
     ) {
       return foundEls;
     }


### PR DESCRIPTION
Ran into this issue when I tried adding conditional elements towards the top of a vdom branch.  For example:

```coffee
m 'section.modal__content', [
  if ctrl.error()
    m '.flash.error.centi', ctrl.error()

  m '#otherContent.shortenedForClarity'
]
```

The result is a vdom elem that looks something like this (when `ctrl.error()` is falsy):

```
{ tag: 'section',
  attrs: { className: 'modal__content' },
  children: [ undefined, [ [Object], [Object] ] ],
  parent: 
   { tag: 'div',
     attrs: { className: 'modal__wrapper', config: [Object] },
     children: [ [Object], [Circular], [Object] ],
     parent: { tag: 'div', attrs: [Object], children: [Object] } } }
```

Notice the `undefined` first child.  As a result, all of the remaining children after it were invisible to `find`.  This should fix it.