### PR TITLE
Treat trusted strings as normal strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ function isFuction(thing) {
   return typeof thing === 'function';
 }
 
+function isTrusted(thing) {
+  return thing.$trusted;
+}
+
 function call(thing) {
   return thing();
 }
@@ -143,7 +147,7 @@ function scan(render) {
     if (!el) {
       return false;
     }
-    if (isString(el)) {
+    if (isString(el) || isTrusted(el)) {
       return el.indexOf(value) >= 0;
     }
     if (isString(el.children)) {

--- a/test.js
+++ b/test.js
@@ -89,6 +89,14 @@ describe('mithril query', function() {
       expect(out.contains('Inner String')).to.be.ok();
       expect(out.contains(123)).to.ok();
     });
+
+    describe('trusted content', function() {
+      it('should allow to select by content', function() {
+        var out = mq(m('.containstest', [m.trust('<p>Trusted String</p>'), 'Inner String']));
+        expect(out.contains('Inner String')).to.be.ok();
+        expect(out.contains('Trusted String')).to.be.ok();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
so the `contains` test will work with trusted content