### PR TITLE
Mocking event target

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,7 +264,7 @@ function scan (render) {
       options = options || {}
       var keyCode = isString(key) ? code(key) : key
       fire(selector, {
-        target: {value: options.value},
+        target: options.target || {value: options.value},
         altKey: !!options.altKey,
         shiftKey: !!options.shiftKey,
         ctrlKey: !!options.ctrlKey,

--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ function scan (render) {
 
   function triggerKey (eventName) {
     var fire = trigger(eventName)
-    return function keydown (selector, key, options) {
+    return function handleEvent (selector, key, options) {
       options = options || {}
       var keyCode = isString(key) ? code(key) : key
       fire(selector, {


### PR DESCRIPTION
Currently, you may only inject event targets value. This change allows you to inject the whole target.