### PR TITLE
Fix typescript typing for MithrilQueryInstance.rootEl

### DIFF
--- a/mithril-query.d.ts
+++ b/mithril-query.d.ts
@@ -10,7 +10,7 @@ interface KeyEventOptions {
 }
 
 interface MithrilQueryInstance {
-  rootNode: any
+  rootEl: any
   redraw: () => void
   first: (selector: string) => any
   has: (selector: string) => boolean


### PR DESCRIPTION
## Description
The type definition in `mithril-query.d.ts` has a definition for `MithrilQueryInstance.rootNode`. But the library uses `rootEl`, which leads to `rootNode` always being undefined.

## Motivation and Context
This pull request fixes an issue with MithrilQueryInstance.rootNode being undefined.

## How Has This Been Tested?
Only manual testing. This one-line change only affects IDE typing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read all applicable contributing documents.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the change log (if applicable).
